### PR TITLE
Better integration with Tasmota features

### DIFF
--- a/tmp117.be
+++ b/tmp117.be
@@ -13,8 +13,8 @@ class TMP117: Driver
   var temperature     # temperature result in °C
   var ready           # true if sensor is available and not busy
   var temp_format     # function to convert temperature to formatted string
-  var tempres         # number of decimals from Tasmota settings
-  var tempoffset      # temperature offset config, from Tasmota settings
+  var tempres
+  var tempoffset
 
   def init()
     self.wire = tasmota.wire_scan(self.sensor_addr, 58)
@@ -25,9 +25,9 @@ class TMP117: Driver
     self.tempres    = 2
     self.tempoffset = 0
     self.create_formatter()
-    tasmota.add_rule("TempRes",    / value -> self.create_formatter(value))
-    tasmota.add_rule("TempOffset", / value -> self.create_formatter(nil, value))
-    tasmota.add_rule("SetOption8", / value -> self.create_formatter())
+    tasmota.add_rule("TempRes",    /value->self.create_formatter(value))
+    tasmota.add_rule("TempOffset", /value->self.create_formatter(nil,value))
+    tasmota.add_rule("SetOption8", /value->self.create_formatter())
     tasmota.cmd("Backlog TempRes; TempOffset")
     #- initialize sensor, if other measurement method is required -#
   end
@@ -80,8 +80,9 @@ class TMP117: Driver
   def web_sensor()
     if !self.wire return nil end  #- exit if not initialized -#
     import string
+    var temp_format = self.temp_format
     var msg = string.format("{s}%s %s{m}%s{e}",
-              self.sensor_name, self.temp_label, self.temp_format(self.temperature, true))
+              self.sensor_name, self.temp_label, temp_format(self.temperature, true))
     tasmota.web_send_decimal(msg)
   end
 
@@ -89,8 +90,9 @@ class TMP117: Driver
   def json_append()
     if !self.wire return nil end  #- exit if not initialized -#
     import string
+    var temp_format = self.temp_format
     var msg = string.format(',"%s":{"%s":%s}',
-              self.sensor_name, self.temp_label, self.temp_format(self.temperature, false))
+              self.sensor_name, self.temp_label, temp_format(self.temperature, false))
     tasmota.response_append(msg)
   end
 

--- a/tmp117.be
+++ b/tmp117.be
@@ -13,8 +13,8 @@ class TMP117: Driver
   var temperature     # temperature result in °C
   var ready           # true if sensor is available and not busy
   var temp_format     # function to convert temperature to formatted string
-  var tempres
-  var tempoffset
+  var tempres         # number of decimals from Tasmota settings
+  var tempoffset      # temperature offset config, from Tasmota settings
 
   def init()
     self.wire = tasmota.wire_scan(self.sensor_addr, 58)
@@ -25,9 +25,9 @@ class TMP117: Driver
     self.tempres    = 2
     self.tempoffset = 0
     self.create_formatter()
-    tasmota.add_rule("TempRes",    /value->self.create_formatter(value))
-    tasmota.add_rule("TempOffset", /value->self.create_formatter(nil,value))
-    tasmota.add_rule("SetOption8", /value->self.create_formatter())
+    tasmota.add_rule("TempRes",    /value -> self.create_formatter(value))
+    tasmota.add_rule("TempOffset", /value -> self.create_formatter(nil,value))
+    tasmota.add_rule("SetOption8", /value -> self.create_formatter())
     tasmota.cmd("Backlog TempRes; TempOffset")
     #- initialize sensor, if other measurement method is required -#
   end

--- a/tmp117.be
+++ b/tmp117.be
@@ -4,22 +4,47 @@
  - Support for TMP117 device
  -#
 
-var SENSOR_ADDR = 0x48
-
 class TMP117: Driver
+  static sensor_name = "TMP117"       # sensor name
+  static sensor_addr = 0x48           # I2C bus address for sensor
+  static temp_label  = "Temperature"  # label for temperature in language of preference
+
   var wire            #- if wire == nil then the module is not initialized -#
   var temperature     # temperature result in °C
   var ready           # true if sensor is available and not busy
+  var temp_format     # function to convert temperature to formatted string
+  var tempres         # number of decimals from Tasmota settings
+  var tempoffset      # temperature offset config, from Tasmota settings
 
   def init()
-    self.wire = tasmota.wire_scan(SENSOR_ADDR, 58)
-
+    self.wire = tasmota.wire_scan(self.sensor_addr, 58)
     if self.wire
       #- write config Register / initialize Sensor -#
-      print("I2C: TMP117 detected on bus "+str(self.wire.bus))
+      print("I2C: "..self.sensor_name.." detected on bus "+str(self.wire.bus))
     end
+    self.tempres    = 2
+    self.tempoffset = 0
+    self.create_formatter()
+    tasmota.add_rule("TempRes",    / value -> self.create_formatter(value))
+    tasmota.add_rule("TempOffset", / value -> self.create_formatter(nil, value))
+    tasmota.add_rule("SetOption8", / value -> self.create_formatter())
+    tasmota.cmd("Backlog TempRes; TempOffset")
+    #- initialize sensor, if other measurement method is required -#
+  end
 
-    #- initialize sensor, if other mesurement method is required -#
+  def create_formatter(tempres,tempoffset)
+    if tempres    != nil self.tempres    = tempres    end
+    if tempoffset != nil self.tempoffset = tempoffset end
+    var fahrenheit = tasmota.get_option(8) == 1
+    print(self.sensor_name, "TempRes:"..self.tempres, "TempOffset:"..self.tempoffset, "Fahrenheit:"..fahrenheit)
+    var tempmask = "%." .. self.tempres .. "f"
+    self.temp_format = 
+      def (temperature, display) 
+        import string
+        return string.format(
+          tempmask .. (display ? " °" .. (fahrenheit ? "F" : "C") : ""), 
+          (fahrenheit ? temperature * 1.8 + 32 : temperature) + self.tempoffset)
+      end
   end
 
   #- returns the resolution temperature -#
@@ -29,18 +54,18 @@ class TMP117: Driver
     #- sanity-check if sensor is accessible and ready
      - (check bus-acknowledge and ready-Flag) 
      -#
-    self.ready = self.wire.write(SENSOR_ADDR, 0x00, 0x00, 1)
+    self.ready = self.wire.write(self.sensor_addr, 0x00, 0x00, 1)
     if !self.ready return nil end  #- exit if not available -#
     
     # todo: read and check acknowledge-flag
     # if !self.ready return nil end  #- exit if not ready -#
 
-    var b = self.wire.read_bytes(SENSOR_ADDR, 0x00, 2)
+    var b = self.wire.read_bytes(self.sensor_addr, 0x00, 2)
     var t = b.get(0,-2)
 
     # todo: check for 0x8000 initial value
     
-    self.temperature = t*0.0078125
+    self.temperature = real(t)/128
     return self.temperature
   end
 
@@ -55,9 +80,8 @@ class TMP117: Driver
   def web_sensor()
     if !self.wire return nil end  #- exit if not initialized -#
     import string
-    var msg = string.format(
-             "{s}TMP117 Temperatur{m}%.3f °C{e}",
-              self.temperature)
+    var msg = string.format("{s}%s %s{m}%s{e}",
+              self.sensor_name, self.temp_label, self.temp_format(self.temperature, true))
     tasmota.web_send_decimal(msg)
   end
 
@@ -65,8 +89,8 @@ class TMP117: Driver
   def json_append()
     if !self.wire return nil end  #- exit if not initialized -#
     import string
-    var msg = string.format(",\"TMP117\":{\"Temperature\":%.3f}",
-              self.temperature)
+    var msg = string.format(',"%s":{"%s":%s}',
+              self.sensor_name, self.temp_label, self.temp_format(self.temperature, false))
     tasmota.response_append(msg)
   end
 


### PR DESCRIPTION
Using the driver with a TMP117 sensor, I observed how the driver did not support features TempOffset, TempRes and SetOption8 (fahrenheit). Added this support, including allowing changes while running. Also made a couple of tweaks to take advantage of newer Tasmota features. 

Another reason to avoid the global `SENSOR_ADDR` is that this could clash with other drivers using the same name. While this could have been handled prefixing the name of the global variable, the new feature of static variables is very nice for such fixed setup. Also made the temperature translation static, observed how the existing driver used the name "Temperatur", which fits some languages only :-)